### PR TITLE
Add github action and script for auto lunch menu upload

### DIFF
--- a/.github/workflows/update-menu-image.yml
+++ b/.github/workflows/update-menu-image.yml
@@ -1,0 +1,102 @@
+name: Update Menu Image
+
+on:
+  push:
+    branches:
+      - menu-upload-inbox
+    paths:
+      - ".menu-upload-inbox/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: menu-image-publisher
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout inbox branch
+        uses: actions/checkout@v4
+        with:
+          ref: menu-upload-inbox
+          fetch-depth: 1
+          path: inbox
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          path: repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install processing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils
+          python -m pip install --upgrade pip
+          python -m pip install Pillow
+
+      - name: Locate pending upload
+        id: upload
+        working-directory: inbox
+        run: |
+          if [ ! -f .menu-upload-inbox/upload ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "path=.menu-upload-inbox/upload" >> "$GITHUB_OUTPUT"
+
+      - name: Process upload into live menu assets
+        if: steps.upload.outputs.found == 'true'
+        run: >
+          python repo/scripts/process_menu_upload.py
+          --input "inbox/${{ steps.upload.outputs.path }}"
+          --output repo/public/menu/menu.jpg
+          --backup repo/public/menu/menu_old.jpg
+
+      - name: Publish processed assets to main
+        if: steps.upload.outputs.found == 'true'
+        working-directory: repo
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/menu/menu.jpg public/menu/menu_old.jpg
+
+          if git diff --cached --quiet; then
+            echo "No asset changes to publish."
+            exit 0
+          fi
+
+          git commit -m "chore: update lunch menu image"
+          git push origin HEAD:main
+
+      - name: Clear processed inbox item
+        if: steps.upload.outputs.found == 'true'
+        working-directory: inbox
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          rm -f .menu-upload-inbox/upload
+          rmdir .menu-upload-inbox 2>/dev/null || true
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Inbox already empty."
+            exit 0
+          fi
+
+          git commit -m "chore: clear menu upload inbox"
+          git push origin HEAD:menu-upload-inbox

--- a/scripts/process_menu_upload.py
+++ b/scripts/process_menu_upload.py
@@ -1,0 +1,114 @@
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+
+SUPPORTED_SUFFIXES = {".pdf", ".jpg", ".jpeg"}
+PDF_SIGNATURE = b"%PDF-"
+JPEG_SIGNATURE = b"\xff\xd8\xff"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Normalize an uploaded lunch menu asset into the live JPG path.",
+    )
+    parser.add_argument("--input", required=True, type=Path, dest="input_path")
+    parser.add_argument("--output", required=True, type=Path, dest="output_path")
+    parser.add_argument("--backup", required=True, type=Path, dest="backup_path")
+    return parser.parse_args()
+
+
+def detect_upload_type(input_path: Path) -> str:
+    if not input_path.exists():
+        raise RuntimeError(f"Upload file does not exist: {input_path}")
+
+    suffix = input_path.suffix.lower()
+    if suffix in SUPPORTED_SUFFIXES:
+        return suffix
+
+    with input_path.open("rb") as file_obj:
+        signature = file_obj.read(8)
+    if signature.startswith(PDF_SIGNATURE):
+        return ".pdf"
+    if signature.startswith(JPEG_SIGNATURE):
+        return ".jpg"
+
+    supported = ", ".join(sorted(SUPPORTED_SUFFIXES))
+    raise RuntimeError(
+        f"Unsupported upload type for {input_path}. Expected one of: {supported}, PDF bytes, or JPEG bytes",
+    )
+
+
+def render_pdf_to_jpeg(input_path: Path, temp_dir: Path) -> Path:
+    output_prefix = temp_dir / "menu-first-page"
+    try:
+        subprocess.run(
+            [
+                "pdftoppm",
+                "-jpeg",
+                "-f",
+                "1",
+                "-singlefile",
+                "-r",
+                "200",
+                str(input_path),
+                str(output_prefix),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("pdftoppm is required to process PDF uploads") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() or exc.stdout.strip() or "unknown pdftoppm failure"
+        raise RuntimeError(f"Failed to rasterize PDF upload: {stderr}") from exc
+
+    rendered_path = output_prefix.with_suffix(".jpg")
+    if not rendered_path.exists():
+        raise RuntimeError("PDF conversion did not produce an output image")
+    return rendered_path
+
+
+def normalize_to_jpeg(source_path: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with Image.open(source_path) as image:
+        normalized = ImageOps.exif_transpose(image).convert("RGB")
+        normalized.save(
+            output_path,
+            format="JPEG",
+            quality=90,
+            optimize=True,
+            progressive=True,
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    suffix = detect_upload_type(args.input_path)
+
+    with tempfile.TemporaryDirectory(prefix="menu-upload-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        normalized_source = args.input_path
+        if suffix == ".pdf":
+            normalized_source = render_pdf_to_jpeg(args.input_path, temp_dir)
+
+        temp_output = temp_dir / "menu.jpg"
+        normalize_to_jpeg(normalized_source, temp_output)
+
+        if args.output_path.exists():
+            args.backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(args.output_path, args.backup_path)
+
+        shutil.copy2(temp_output, args.output_path)
+
+    print(f"Updated {args.output_path} and rotated backup to {args.backup_path}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add GitHub action and script that connects to this menu admin dashboard: https://bay-clock-menu-admin.kainoanewton.workers.dev/

https://github.com/notkainoa/bay-clock-menu-admin

Login:
<img width="1056" height="853" alt="image" src="https://github.com/user-attachments/assets/65fc0d36-2b31-4e75-a0a1-281f243da25d" />

Upload menu:
<img width="1069" height="862" alt="image" src="https://github.com/user-attachments/assets/18a2e13a-b3e8-428e-be7a-4ad0589234ec" />

Compare/make sure you uploaded the right thing:
<img width="1070" height="874" alt="image" src="https://github.com/user-attachments/assets/ecb42d3b-2d4c-4d7c-995a-3bac1ac09af6" />

Watch the new menu get uploaded, committed, and deployed:
<img width="1079" height="878" alt="image" src="https://github.com/user-attachments/assets/a0b1edc2-b71d-4476-98d2-03747ea70614" />
